### PR TITLE
ci: add workflow to publish documentation

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,38 @@
+name: Publishing documentation
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Install dependencies 📦
+        run: pip install -r requirements.txt
+
+      - name: Build documentation 🔨
+        run: make html
+
+      # add .nojekyll to the root so that github won't 404 on content
+      # that start with an underscore (_)
+      - name: Add nojekyll for Github Pages
+        run: touch _build/html/.nojekyll
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@releases/v3
+        with:
+          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: latestHTML
+          # note: FOLDER doesn't care about the job's working directory
+          FOLDER: _build/html
+          SINGLE_COMMIT: true


### PR DESCRIPTION
This PR adds a Github Actions workflow to automatically build and republish the documentation on the Github Pages, at the `latestHTML` branch.
