### PR TITLE
ci: pin github-pages-deploy-action to v4.2.5's SHA1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,10 +29,10 @@ jobs:
         run: touch _build/html/.nojekyll
 
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@releases/v3
+        # pin v4.2.5 commit SHA1
+        uses: JamesIves/github-pages-deploy-action@830e6a4f7c81743c52f3fed0ac67428feff9620a
         with:
-          ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: latestHTML
+          branch: latestHTML
           # note: FOLDER doesn't care about the job's working directory
-          FOLDER: _build/html
-          SINGLE_COMMIT: true
+          folder: _build/html
+          single-commit: true


### PR DESCRIPTION
This PR pins the 3rd party action https://github.com/JamesIves/github-pages-deploy-action to the latest version (4.2.5) with the commit's SHA1, according to the best practises of  https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions