### PR TITLE
Fix tables wrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+build/
+venv/
+
+# ide
+.vscode/

--- a/source/_static/css/wrapped_table.css
+++ b/source/_static/css/wrapped_table.css
@@ -1,0 +1,4 @@
+/* https://knowyourtoolset.com/2018/02/controlling-the-width-of-a-table-with-read-the-docs/ */
+.wrapped-table td {
+    white-space: normal !important
+}

--- a/source/conf.py
+++ b/source/conf.py
@@ -145,7 +145,13 @@ html_title = "Intel® Trust Domain Extension"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-#html_static_path = ['_static']
+html_static_path = ['_static']
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    'css/wrapped_table.css',
+]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/source/security-spec.rst
+++ b/source/security-spec.rst
@@ -304,8 +304,8 @@ The table below shows the allow list ports in the current TDX guest
 kernel:
 
 .. list-table:: List ports
-   :widths: 7 7 10
    :header-rows: 1
+   :class: wrapped-table
 
 
    * - Port range
@@ -366,8 +366,8 @@ Unsafe CPUIDs
 ~~~~~~~~~~~~~
 
 .. list-table:: Unsafe CPUIDs
-   :widths: 20 55
    :header-rows: 1
+   :class: wrapped-table
 
    * - CPUID
      - Notes
@@ -427,8 +427,8 @@ The table below lists the CPUID leaves that can be supplied by the
 untrusted Host/VMM:
 
 .. list-table:: CPUID leaves
-   :widths: 15 20 40
    :header-rows: 1
+   :class: wrapped-table
 
    * - Cpuid Leaf
      - Purpose

--- a/source/tdx-guest-hardening.rst
+++ b/source/tdx-guest-hardening.rst
@@ -119,8 +119,8 @@ ACPI table, or KVM CPUID functionality that is required for a particular
 deployment scenario.
 
 .. list-table:: Filter status
-   :widths: 10 30
    :header-rows: 1
+   :class: wrapped-table
 
    * - Filter name
      - Purpose and current state
@@ -181,8 +181,8 @@ of the code involved, as well as the fact that this functionality is not
 needed for the TD guest kernel.
 
 .. list-table:: Features
-   :widths: 15 60
    :header-rows: 1
+   :class: wrapped-table
 
    * - Feature type
      - Description
@@ -383,8 +383,8 @@ Each finding is therefore manually classified into one of the following
 statuses:
 
 .. list-table:: Findings
-   :widths: 15 60
    :header-rows: 1
+   :class: wrapped-table
 
 
    * - **Status**


### PR DESCRIPTION
This PR fixes the table wrapping.

The `:widths:` options wasn't useful because of some specifities used by the [RTD](https://github.com/readthedocs/sphinx_rtd_theme) theme.

It's a know problem and I followed this blogpost to provide a solution:
https://knowyourtoolset.com/2018/02/controlling-the-width-of-a-table-with-read-the-docs/

This has been fixed with a custom CSS adding a new class, and using that class for every `list-table` now.

before:
![image](https://user-images.githubusercontent.com/964610/161512610-5fd5d97c-9ebe-4878-b5b4-d455d7b9d218.png)

now:
![image](https://user-images.githubusercontent.com/964610/161512742-e3277364-3011-429e-967e-2bf48e13e602.png)

Note: the table title is also centered now.
