### PR TITLE
conf.py: fix deprecrated add_stylesheet

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -211,7 +211,7 @@ html_show_copyright = True
 htmlhelp_basename = 'clrdoc'
 
 def setup(app):
-   app.add_stylesheet("css/table-wrap.css")
+   app.add_css_file("css/table-wrap.css")
 
 # -- Options for LaTeX output ---------------------------------------------
 


### PR DESCRIPTION
`add_stylesheet` is deprecated:
https://github.com/intel/ccc-linux-guest-hardening-docs/runs/7086634711?check_suite_focus=true#step:5:12

use new `add_css_file` API instead
https://www.sphinx-doc.org/en/master/extdev/appapi.html#sphinx.application.Sphinx.add_css_file