### PR TITLE
requirements: pin Sphinx to 6.1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sphinx
+Sphinx==6.1.3


### PR DESCRIPTION
Pin Sphinx version to `6.1.3`, since it's the last release (10th January) before the last known commit where the CI was green (https://github.com/intel/ccc-linux-guest-hardening-docs/commit/97e81a1c10f36694ff40f7cbd568806b88772912, 6th April)